### PR TITLE
fix: check for a valid country before formatting

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,13 +45,13 @@ export const splitPhoneNumber = (value: string): PhoneNumber | undefined => {
   const [country] = countries.filter(
     (c) =>
       dial.startsWith(c[3]) &&
-      (c[6] ? c[6].some((a) => dial.startsWith(`${c[3]}${a}`)) : true)
+      (c[6] ? c[6].some((a:string) => dial.startsWith(`${c[3]}${a}`)) : true)
   );
 
   return {
     raw: value,
     country: country,
-    formatted: applyMask(replaceDialCode(value, country[3], ''), country[4]),
+    formatted: country ? applyMask(replaceDialCode(value, country[3], ''), country[4]) : value,
   };
 };
 


### PR DESCRIPTION
Fixes #524 

- There is an issue with the country lookup happening [here](https://github.com/jorisre/react-telephone/blob/main/src/utils.ts#L45)
- The input could be an invalid country, thereby returning undefined, and causing an uncaught exception in the next line